### PR TITLE
Use 'official' capitalization in DataLad project name

### DIFF
--- a/book/data_management.md
+++ b/book/data_management.md
@@ -946,15 +946,15 @@ When the relevant data are small (e.g. smaller than a few megabytes) and stored 
 
 However, git does not work well for version control on larger datasets using binary data files.  Git is able to efficiently store version information about code because it tracks the specific differences in the code between versions (known as a *diff*), and only stores the differences.  Thus, if one has a very large code file and changes one line, only that one line difference is stored in the git database.  However, with binary data this strategy is not effective, and git has to store the entire new dataset each time, leading to bloated repositories and very slow performance. 
 
-### Using Datalad for version control on larger datasets
+### Using DataLad for version control on larger datasets
 
-A solution to this problem is to use a version control tool that is specifically designed for large data.  There are several tools that address this problem; we will focus on [Datalad](https://www.datalad.org/), which is a data management system that functions very similarly to git.  It is based on a tool called [git-annex](https://git-annex.branchable.com/), but provides much greater ease of use for researchers.  (Full disclosure: Our group collaborates with the Datalad group and our grants have supported some of their development work.)
+A solution to this problem is to use a version control tool that is specifically designed for large data.  There are several tools that address this problem; we will focus on [DataLad](https://www.datalad.org/), which is a data management system that functions very similarly to git.  It is based on a tool called [git-annex](https://git-annex.branchable.com/), but provides much greater ease of use for researchers.  (Full disclosure: Our group collaborates with the DataLad group and our grants have supported some of their development work.)
 
-An important note:  Datalad is quite powerful but has a significant learning curve, and takes a bit of time to get accustomed to.  In particular, its use of symbolic links can sometimes confuse new users. Having said that, let's look at some simple examples.
+An important note:  DataLad is quite powerful but has a significant learning curve, and takes a bit of time to get accustomed to.  In particular, its use of symbolic links can sometimes confuse new users. Having said that, let's look at some simple examples.
 
-#### Creating a local Datalad dataset
+#### Creating a local DataLad dataset
 
-Let's say that we want to create a new dataset on our local computer that will be tracked by Datalad.  We first create a new repository:
+Let's say that we want to create a new dataset on our local computer that will be tracked by DataLad.  We first create a new repository:
 
 ```bash
 ➤  datalad create my_datalad_repo
@@ -962,7 +962,7 @@ Let's say that we want to create a new dataset on our local computer that will b
 create(ok): /Users/poldrack/Dropbox/code/BetterCodeBetterScience/my_datalad_repo (dataset)
 ```
 
-This creates a new directory, called `my_datalad_repo` and sets it up as a Datalad dataset.  We then go into the directory and create a subdirectory called `data`, and then download some data files from another project.  We do this using the `datalad download-url` function, which will both download the data and save them to the datalad dataset:
+This creates a new directory, called `my_datalad_repo` and sets it up as a DataLad dataset.  We then go into the directory and create a subdirectory called `data`, and then download some data files from another project.  We do this using the `datalad download-url` function, which will both download the data and save them to the datalad dataset:
 
 ```bash
 ➤  cd my_datalad_repo
@@ -992,7 +992,7 @@ action summary:
   save (ok: 1)
 ```
 
-A Datalad dataset is also a `git` repository, which we can see if we use the `git log` command:
+A DataLad dataset is also a `git` repository, which we can see if we use the `git log` command:
 
 ```bash
 ➤  git log
@@ -1022,11 +1022,11 @@ Date:   Sun Nov 16 12:12:08 2025 -0800
     [DATALAD] new dataset
 ```
 
-Here we see the commit messages that were automatically created by Datalad, first for creating the new dataset and then for downloading the URLS.  The `datalad download-url` function adds the URL to the log, which is useful for provenance tracking.
+Here we see the commit messages that were automatically created by DataLad, first for creating the new dataset and then for downloading the URLS.  The `datalad download-url` function adds the URL to the log, which is useful for provenance tracking.
 
 #### Modifying files
 
-Now let's say that we want to make a change to one of the files and save the changes to the dataset.  Files tracked by Datalad are read-only ("locked") by default.  If we want to edit them, then we need to use `datalad unlock` to unlock the file:
+Now let's say that we want to make a change to one of the files and save the changes to the dataset.  Files tracked by DataLad are read-only ("locked") by default.  If we want to edit them, then we need to use `datalad unlock` to unlock the file:
 
 ```bash
 ➤  datalad unlock data/demographics.csv
@@ -1059,7 +1059,7 @@ action summary:
   save (ok: 1)
 ```
 
-Datalad doesn't have a staging area like `git` does, so there is no need to first add and then commit the file; `datalad save` is equivalent to adding and then committing the changes. If we then check the status we see that there are no changes waiting to be saved:
+DataLad doesn't have a staging area like `git` does, so there is no need to first add and then commit the file; `datalad save` is equivalent to adding and then committing the changes. If we then check the status we see that there are no changes waiting to be saved:
 
 ```bash
 ➤  datalad status
@@ -1069,9 +1069,9 @@ nothing to save, working tree clean
 
 #### Pushing data to a remote repository
 
-Datalad is a particularly powerful tool for sharing data across systems.  It allows one to push or pull data from a number of different remote storage systems; in this example we will use the [Open Science Framework (OSF)](https://osf.io/) as our storage location, because it is particularly easy to use with Datalad.
+DataLad is a particularly powerful tool for sharing data across systems.  It allows one to push or pull data from a number of different remote storage systems; in this example we will use the [Open Science Framework (OSF)](https://osf.io/) as our storage location, because it is particularly easy to use with DataLad.
 
-We first need to install and set up the `datalad-osf` Python package, per [the Datalad documentation](https://docs.datalad.org/projects/osf/en/latest/settingup.html).  We also need to create an account on the OSF site, and obtain a Personal Access Token for login.  We can then use Datalad to authenticate with OSF:
+We first need to install and set up the `datalad-osf` Python package, per [the DataLad documentation](https://docs.datalad.org/projects/osf/en/latest/settingup.html).  We also need to create an account on the OSF site, and obtain a Personal Access Token for login.  We can then use DataLad to authenticate with OSF:
 
 ```bash
 ➤  datalad osf-credentials                                                1 ↵
@@ -1080,7 +1080,7 @@ token:
 osf_credentials(ok): [authenticated as Russell Poldrack <poldrack@stanford.edu>]
 ```
 
-Having authenticated with OSF, we can now create a new OSF project using Datalad:
+Having authenticated with OSF, we can now create a new OSF project using DataLad:
 
 ```bash
 ➤  datalad create-sibling-osf --title datalad-test-project -s osf
@@ -1137,7 +1137,7 @@ action summary:
      523    1276   58237 data/demographics.csv
 ```
 
-One can also push data using Datalad to a range of other remote hosts; see the [Datalad documentation](https://handbook.datalad.org/en/latest/basics/101-138-sharethirdparty.html) for more on this.
+One can also push data using DataLad to a range of other remote hosts; see the [DataLad documentation](https://handbook.datalad.org/en/latest/basics/101-138-sharethirdparty.html) for more on this.
 
 
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -64,7 +64,7 @@ dataclass
 dataclasses
 dataframe
 datalad
-Datalad
+DataLad
 DATALAD
 dataurl
 davinci

--- a/src/BetterCodeBetterScience/data_management.ipynb
+++ b/src/BetterCodeBetterScience/data_management.ipynb
@@ -918,7 +918,7 @@
    "id": "a5b01f42",
    "metadata": {},
    "source": [
-    "### Datalad\n"
+    "### DataLad\n"
    ]
   },
   {


### PR DESCRIPTION
FYI: if you get my `git-sedi`:

```bash
#!/bin/bash

git grep -l -z "$1" | tr '\n' '\000' | xargs -0 -r -0 sed -i -e "s^$1^$2^g"
```

because commit has a record:

```json
{
 "chain": [],
 "cmd": "git-sedi Datalad DataLad",
 "exit": 0,
 "extra_inputs": [],
 "inputs": [],
 "outputs": [],
 "pwd": "."
}
```

you can just [`datalad rerun c6c3b0f8ccb32e4acfc74024af7df7511bf9bd15`](https://docs.datalad.org/en/stable/generated/man/datalad-rerun.html) to redo that "functional patch" at a later point in time. Or you could potentially "rebase" entire branch with such a functional patch using `--onto` option of rerun